### PR TITLE
Embassy support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ edition = "2021"
 default-features = ["tokio"]
 tokio = ["std", "dep:tokio", "dep:tokio-stream", "dep:tokio-util"]
 std = []
+observable = []
 embassy = ["dep:oneshot", "dep:embassy-util", "dep:embassy-executor", "dep:embassy-net", "dep:watch"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,22 +10,39 @@ categories = ["network-programming"]
 keywords = ["coap", "server", "async", "IoT"]
 edition = "2021"
 
+[features]
+default-features = ["tokio"]
+tokio = ["std", "dep:tokio", "dep:tokio-stream", "dep:tokio-util"]
+std = []
+embassy = ["dep:oneshot", "dep:embassy-util", "dep:embassy-executor", "dep:embassy-net", "dep:watch"]
+
 [dependencies]
-tokio = { version = "1.17.0", features = ["full"] }
-tokio-stream = "0.1.8"
-tokio-util = { version = "0.7.0", features = ["codec", "net"] }
-bytes = "1.1.0"
-futures = "0.3.21"
+tokio = { version = "1.17.0", features = ["full"], optional = true }
+tokio-stream = { version = "0.1.8", optional = true }
+tokio-util = { version = "0.7.0", features = ["codec", "net"], optional = true }
+thingbuf = { version = "0.1", default-features = false }
+bytes = { version = "1.1.0", default-features = false }
+futures = { version = "0.3.21", default-features = false }
 async-trait = "0.1.53"
 pin-project = "1.0.10"
 sync_wrapper = "0.1.1"
 dyn-clone = "1.0.5"
-anyhow = "1.0.56"
-thiserror = "1.0.30"
-env_logger = "0.9.0"
-log = "0.4.16"
-coap-lite = "0.9.0"
-rand = "0.8.5"
+anyhow = { version = "1.0.56", default-features = false }
+log = { version = "0.4.16", default-features = false }
+coap-lite = { path = "../coap-lite", default-features = false }
+rand = { version = "0.8", default-features = false }
+hashbrown = "0.12"
+
+embassy-executor = { path = "../embassy/embassy-executor", default-features = false, optional = true }
+embassy-net = { path = "../embassy/embassy-net", default-features = false, optional = true }
+oneshot = { version = "0.1", default-features = false, features = ["async"], optional = true }
+watch = { path = "../watch", default-features = false, optional = true }
+
+[target.'cfg(target_os = "none")'.dependencies]
+embassy-util = { path = "../embassy/embassy-util", default-features = false, optional = true }
+
+[target.'cfg(not(target_os = "none"))'.dependencies]
+embassy-util = { path = "../embassy/embassy-util", features = ["std"], optional = true }
 
 [dev-dependencies]
 async-stream = "0.3.3"

--- a/src/app/app_builder.rs
+++ b/src/app/app_builder.rs
@@ -1,5 +1,8 @@
-use std::fmt::Debug;
-use std::hash::Hash;
+use core::fmt::Debug;
+use core::hash::Hash;
+
+use alloc::vec::Vec;
+use rand::Rng;
 
 use crate::app::app_handler::AppHandler;
 use crate::app::ResourceBuilder;
@@ -92,10 +95,12 @@ impl<Endpoint: Ord + Clone> AppBuilder<Endpoint> {
     }
 }
 
-impl<Endpoint: Debug + Clone + Ord + Eq + Hash + Send + 'static>
-    IntoHandler<AppHandler<Endpoint>, Endpoint> for AppBuilder<Endpoint>
+impl<
+        Endpoint: Debug + Clone + Ord + Eq + Hash + Send + 'static,
+        R: Rng + Send + Sync + Clone + 'static,
+    > IntoHandler<AppHandler<Endpoint, R>, Endpoint, R> for AppBuilder<Endpoint>
 {
-    fn into_handler(self, mtu: Option<u32>) -> AppHandler<Endpoint> {
-        AppHandler::from_builder(self, mtu)
+    fn into_handler(self, mtu: Option<u32>, rng: R) -> AppHandler<Endpoint, R> {
+        AppHandler::from_builder(self, mtu, rng)
     }
 }

--- a/src/app/app_handler.rs
+++ b/src/app/app_handler.rs
@@ -1,15 +1,20 @@
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::pin::Pin;
-use std::sync::Arc;
+use alloc::boxed::Box;
+use alloc::fmt::Debug;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::pin::Pin;
+use core::{hash::Hash, task::Poll};
+use hashbrown::HashMap;
+use pin_project::pin_project;
+use rand::Rng;
 
 use coap_lite::{BlockHandler, CoapRequest, MessageClass, MessageType, Packet};
-use futures::Stream;
+#[cfg(feature = "embassy")]
+use embassy_util::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+use futures::{Future, Stream};
 use log::{debug, warn};
-use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::Mutex;
-use tokio_stream::wrappers::UnboundedReceiverStream;
+#[cfg(feature = "tokio")]
+use tokio::sync::{mpsc::UnboundedSender, Mutex};
 
 use crate::app::app_builder::AppBuilder;
 use crate::app::block_handler_util::new_block_handler;
@@ -29,55 +34,95 @@ pub(crate) const DEFAULT_BLOCK_TRANSFER: bool = true;
 /// Main PacketHandler for an application suite of handlers.  Efficiency and concurrency are
 /// the primary goals of this implementation, but with the need to balance developer friendliness
 /// of the main API.
-pub struct AppHandler<Endpoint: Debug + Clone + Ord + Eq + Hash> {
+pub struct AppHandler<Endpoint: Debug + Clone + Ord + Eq + Hash, R: Clone> {
+    #[cfg(feature = "tokio")]
     retransmission_manager: Arc<Mutex<RetransmissionManager<Endpoint>>>,
+    #[cfg(feature = "embassy")]
+    retransmission_manager: Arc<Mutex<CriticalSectionRawMutex, RetransmissionManager<Endpoint>>>,
 
     /// Special internal [`coap_lite::BlockHandler`] that we use only for formatting errors
     /// that might be larger than MTU.
+    #[cfg(feature = "tokio")]
     error_block_handler: Arc<Mutex<BlockHandler<Endpoint>>>,
+    #[cfg(feature = "embassy")]
+    error_block_handler: Arc<Mutex<CriticalSectionRawMutex, BlockHandler<Endpoint>>>,
 
     /// Full set of handlers registered for this app, grouped by path but searchable using inexact
     /// matching.  See [`PathMatcher`] for more.
     handlers_by_path: Arc<PathMatcher<ResourceHandler<Endpoint>>>,
+    rng: R,
 }
 
-impl<Endpoint: Debug + Clone + Ord + Eq + Hash> Clone for AppHandler<Endpoint> {
+impl<Endpoint: Debug + Clone + Ord + Eq + Hash, R: Clone> Clone for AppHandler<Endpoint, R> {
     fn clone(&self) -> Self {
         Self {
             retransmission_manager: self.retransmission_manager.clone(),
             error_block_handler: self.error_block_handler.clone(),
             handlers_by_path: self.handlers_by_path.clone(),
+            rng: self.rng.clone(),
         }
     }
 }
 
-impl<Endpoint: Debug + Clone + Ord + Eq + Hash + Send + 'static> PacketHandler<Endpoint>
-    for AppHandler<Endpoint>
+#[pin_project]
+struct PacketStream<F: Send> {
+    #[pin]
+    fut: F,
+    response: Vec<Packet>,
+    fut_complete: bool,
+}
+
+impl<F: Future<Output = Vec<Packet>> + Send> Stream for PacketStream<F> {
+    type Item = Packet;
+
+    fn poll_next(
+        self: Pin<&mut Self>,
+        cx: &mut core::task::Context<'_>,
+    ) -> core::task::Poll<Option<Self::Item>> {
+        let this = self.project();
+
+        if !*this.fut_complete {
+            match this.fut.poll(cx) {
+                Poll::Ready(response) => {
+                    *this.response = response;
+                    *this.fut_complete = true;
+                    // FIXME: should use some more efficient container
+                    this.response.reverse();
+                }
+                Poll::Pending => {
+                    return Poll::Pending;
+                }
+            }
+        }
+
+        Poll::Ready(this.response.pop())
+    }
+}
+
+impl<Endpoint: Debug + Clone + Ord + Eq + Hash + Send + 'static, R: Rng + Send + Sync + Clone>
+    PacketHandler<Endpoint> for AppHandler<Endpoint, R>
 {
     fn handle<'a>(
         &'a self,
         packet: Packet,
         peer: Endpoint,
     ) -> Pin<Box<dyn Stream<Item = Packet> + Send + 'a>> {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
-
-        // TODO: This spawn is technically unnecessary as we could implement a Stream ourselves
-        // similar to how async-stream crate does it, but the boiler plate doesn't really seem
-        // worth it for now.
-        tokio::spawn({
-            let cloned_self = self.clone();
-            async move {
-                cloned_self.handle_packet(tx, packet, peer).await;
-            }
-        });
-        Box::pin(UnboundedReceiverStream::new(rx))
+        let handler = self.handle_packet(packet, peer);
+        Box::pin(PacketStream {
+            fut: handler,
+            response: vec![],
+            fut_complete: false,
+        })
     }
 }
 
-impl<Endpoint: Debug + Clone + Ord + Eq + Hash + Send + 'static> AppHandler<Endpoint> {
-    pub fn from_builder(builder: AppBuilder<Endpoint>, mtu: Option<u32>) -> Self {
+impl<Endpoint: Debug + Clone + Ord + Eq + Hash + Send + 'static, R: Rng + Clone>
+    AppHandler<Endpoint, R>
+{
+    pub fn from_builder(builder: AppBuilder<Endpoint>, mtu: Option<u32>, mut rng: R) -> Self {
         let retransmission_manager = Arc::new(Mutex::new(RetransmissionManager::new(
             TransmissionParameters::default(),
+            &mut rng,
         )));
 
         let build_params = BuildParameters {
@@ -110,16 +155,20 @@ impl<Endpoint: Debug + Clone + Ord + Eq + Hash + Send + 'static> AppHandler<Endp
             retransmission_manager,
             error_block_handler,
             handlers_by_path,
+            rng,
         }
     }
 
-    async fn handle_packet(&self, tx: UnboundedSender<Packet>, packet: Packet, peer: Endpoint) {
+    async fn handle_packet(&self, packet: Packet, peer: Endpoint) -> Vec<Packet> {
         match packet.header.code {
             MessageClass::Request(_) => {
-                self.handle_get(tx, packet, peer).await;
+                let mut packets = vec![];
+                self.handle_get(&mut packets, packet, peer).await;
+                packets
             }
             MessageClass::Response(_) => {
                 warn!("Spurious response message from {peer:?}, ignoring...");
+                vec![]
             }
             MessageClass::Empty => {
                 match packet.header.get_type() {
@@ -133,26 +182,30 @@ impl<Endpoint: Debug + Clone + Ord + Eq + Hash + Send + 'static> AppHandler<Endp
                                 "Got {t:?} from {peer:?} for unrecognized message ID {message_id}"
                             );
                         }
+
+                        vec![]
                     }
                     MessageType::Confirmable => {
                         // A common way in CoAP to trigger a cheap "ping" to make sure
                         // the server is alive.
-                        tx.send(new_pong_message(&packet)).unwrap();
+                        vec![new_pong_message(&packet)]
                     }
                     MessageType::NonConfirmable => {
                         debug!("Ignoring Non-Confirmable Empty message from {peer:?}");
+                        vec![]
                     }
                 }
             }
             code => {
                 warn!("Unhandled message code {code} from {peer:?}, ignoring...");
+                vec![]
             }
         }
     }
 
-    async fn handle_get(&self, tx: UnboundedSender<Packet>, packet: Packet, peer: Endpoint) {
+    async fn handle_get(&self, out: &mut Vec<Packet>, packet: Packet, peer: Endpoint) {
         let mut request = CoapRequest::from_packet(packet, peer);
-        if let Err(e) = self.try_handle_get(&tx, &mut request).await {
+        if let Err(e) = self.try_handle_get(out, &mut request).await {
             if request.apply_from_error(e.into_handling_error()) {
                 // If the error happens to need block2 handling, let's do that here...
                 let _ = self
@@ -160,14 +213,14 @@ impl<Endpoint: Debug + Clone + Ord + Eq + Hash + Send + 'static> AppHandler<Endp
                     .lock()
                     .await
                     .intercept_response(&mut request);
-                tx.send(request.response.unwrap().message).unwrap();
+                out.push(request.response.unwrap().message);
             }
         }
     }
 
     async fn try_handle_get(
         &self,
-        tx: &UnboundedSender<Packet>,
+        out: &mut Vec<Packet>,
         request: &mut CoapRequest<Endpoint>,
     ) -> Result<(), CoapError> {
         let paths = request.get_path_as_vec().map_err(CoapError::bad_request)?;
@@ -193,7 +246,8 @@ impl<Endpoint: Debug + Clone + Ord + Eq + Hash + Send + 'static> AppHandler<Endp
                     unmatched_path: Vec::from(&paths[matched_index..]),
                 };
 
-                value.handle(tx, wrapped_request).await
+                let mut rng = self.rng.clone();
+                value.handle(out, wrapped_request, &mut rng).await
             }
             None => Err(CoapError::not_found()),
         }

--- a/src/app/coap_utils.rs
+++ b/src/app/coap_utils.rs
@@ -1,5 +1,7 @@
-use std::collections::HashMap;
+use hashbrown::HashMap;
 
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use coap_lite::error::IncompatibleOptionValueFormat;
 use coap_lite::option_value::OptionValueType;
 use coap_lite::{CoapOption, CoapRequest, MessageClass, MessageType, Packet};

--- a/src/app/core_handler.rs
+++ b/src/app/core_handler.rs
@@ -1,7 +1,10 @@
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::sync::Arc;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::fmt::Debug;
+use core::hash::Hash;
+use hashbrown::HashMap;
 
 use async_trait::async_trait;
 use coap_lite::{ContentFormat, ResponseType};

--- a/src/app/core_link.rs
+++ b/src/app/core_link.rs
@@ -1,9 +1,12 @@
 use crate::app::resource_builder::DiscoverableResource;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
 use coap_lite::link_format::{LinkAttributeWrite, LinkFormatWrite};
 use coap_lite::ContentFormat;
+use core::fmt::{Debug, Error, Write};
 use dyn_clone::DynClone;
-use std::collections::HashMap;
-use std::fmt::{Debug, Error, Write};
+use hashbrown::HashMap;
 
 #[derive(Default, Debug)]
 pub struct CoreLink {

--- a/src/app/error.rs
+++ b/src/app/error.rs
@@ -1,6 +1,7 @@
-use std::fmt::Debug;
-use std::{error, fmt};
+use core::fmt;
+use core::fmt::Debug;
 
+use alloc::string::{String, ToString};
 use coap_lite::error::HandlingError;
 use coap_lite::ResponseType;
 
@@ -51,7 +52,8 @@ impl fmt::Display for CoapError {
     }
 }
 
-impl error::Error for CoapError {}
+#[cfg(feature = "std")]
+impl std::error::Error for CoapError {}
 
 impl From<HandlingError> for CoapError {
     fn from(src: HandlingError) -> Self {

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -2,8 +2,11 @@ pub use app_builder::AppBuilder;
 use core::fmt::Debug;
 use core::hash::Hash;
 pub use error::CoapError;
+#[cfg(feature = "observable")]
 pub use observable_resource::ObservableResource;
+#[cfg(feature = "observable")]
 pub use observers::Observers;
+#[cfg(feature = "observable")]
 pub use observers::ObserversHolder;
 pub use request::Request;
 pub use resource_builder::ResourceBuilder;
@@ -16,8 +19,11 @@ mod coap_utils;
 mod core_handler;
 mod core_link;
 pub mod error;
+#[cfg(feature = "observable")]
 pub mod observable_resource;
+#[cfg(feature = "observable")]
 mod observe_handler;
+#[cfg(feature = "observable")]
 mod observers;
 mod path_matcher;
 pub mod request;

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -1,4 +1,6 @@
 pub use app_builder::AppBuilder;
+use core::fmt::Debug;
+use core::hash::Hash;
 pub use error::CoapError;
 pub use observable_resource::ObservableResource;
 pub use observers::Observers;
@@ -6,8 +8,6 @@ pub use observers::ObserversHolder;
 pub use request::Request;
 pub use resource_builder::ResourceBuilder;
 pub use response::Response;
-use std::fmt::Debug;
-use std::hash::Hash;
 
 pub mod app_builder;
 pub mod app_handler;

--- a/src/app/observable_resource.rs
+++ b/src/app/observable_resource.rs
@@ -1,3 +1,4 @@
+use alloc::boxed::Box;
 use async_trait::async_trait;
 
 use crate::app::observers::Observers;

--- a/src/app/observe_handler.rs
+++ b/src/app/observe_handler.rs
@@ -123,7 +123,7 @@ impl<Endpoint: Eq + Hash + Clone + Send + 'static> ObserveHandler<Endpoint> {
                     let path_key_clone = path_key.clone();
                     /*tokio::spawn(async move {
                         self_clone
-                            .handle_on_active_lifecycle(path_key_clone, observers)
+                            .handle_on_active_lifecycle(path_key_cflone, observers)
                             .await;
                     });
 

--- a/src/app/observe_handler.rs
+++ b/src/app/observe_handler.rs
@@ -3,14 +3,21 @@
 //! Supports handling incoming requests and manipulating outgoing responses transparently to
 //! semi-transparently handle Observe requests from clients in a reasonable and consistent way.
 
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::sync::Arc;
+use alloc::borrow::ToOwned;
+use alloc::boxed::Box;
+use alloc::string::String;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::fmt::Debug;
+use core::hash::Hash;
+use hashbrown::HashMap;
 
 use coap_lite::{CoapRequest, ObserveOption};
+#[cfg(feature = "embassy")]
+use embassy_util::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
 use log::{debug, warn};
-use rand::RngCore;
+use rand::Rng;
+#[cfg(feature = "tokio")]
 use tokio::sync::{oneshot, watch, Mutex};
 
 use crate::app::observers::NotificationState;
@@ -22,7 +29,11 @@ use crate::app::{CoapError, ObservableResource, Observers};
 pub struct ObserveHandler<Endpoint> {
     path_prefix: String,
     resource: Arc<Box<dyn ObservableResource + Send + Sync>>,
+    #[cfg(feature = "tokio")]
     registrations_by_path: Arc<Mutex<HashMap<String, RegistrationsForPath<Endpoint>>>>,
+    #[cfg(feature = "embassy")]
+    registrations_by_path:
+        Arc<Mutex<CriticalSectionRawMutex, HashMap<String, RegistrationsForPath<Endpoint>>>>,
 }
 
 #[derive(Debug)]
@@ -57,9 +68,10 @@ impl<Endpoint: Eq + Hash + Clone + Send + 'static> ObserveHandler<Endpoint> {
         }
     }
 
-    pub async fn maybe_process_registration(
+    pub async fn maybe_process_registration<R: Rng>(
         &self,
         request_response_pair: &mut CoapRequest<Endpoint>,
+        rng: &mut R,
     ) -> Result<RegistrationEvent, CoapError> {
         let observe_flag_result = request_response_pair.get_observe_flag();
         if observe_flag_result.is_none() {
@@ -99,7 +111,7 @@ impl<Endpoint: Eq + Hash + Clone + Send + 'static> ObserveHandler<Endpoint> {
             ObserveOption::Register => {
                 let for_path = by_path.entry(path).or_insert_with_key(|path_key| {
                     let mut u24_bytes = [0u8; 3];
-                    rand::thread_rng().fill_bytes(&mut u24_bytes);
+                    rng.fill_bytes(&mut u24_bytes);
                     let relative_path = path_key.replace(&self.path_prefix, "");
                     let observers = Observers::new(
                         key_from_path(&relative_path),
@@ -109,7 +121,7 @@ impl<Endpoint: Eq + Hash + Clone + Send + 'static> ObserveHandler<Endpoint> {
 
                     let self_clone = self.to_owned();
                     let path_key_clone = path_key.clone();
-                    tokio::spawn(async move {
+                    /*tokio::spawn(async move {
                         self_clone
                             .handle_on_active_lifecycle(path_key_clone, observers)
                             .await;
@@ -118,7 +130,8 @@ impl<Endpoint: Eq + Hash + Clone + Send + 'static> ObserveHandler<Endpoint> {
                     RegistrationsForPath {
                         registrations: HashMap::new(),
                         notify_change_tx,
-                    }
+                    }*/
+                    todo!()
                 });
 
                 let notify_rx = for_path.notify_change_tx.subscribe();

--- a/src/app/path_matcher.rs
+++ b/src/app/path_matcher.rs
@@ -18,6 +18,7 @@ impl<V> FromIterator<(Vec<String>, V)> for PathMatcher<V> {
     }
 }
 
+#[allow(dead_code)]
 impl<V> PathMatcher<V> {
     pub fn new_empty() -> Self {
         Self {

--- a/src/app/path_matcher.rs
+++ b/src/app/path_matcher.rs
@@ -1,5 +1,7 @@
-use std::collections::hash_map::Values;
-use std::collections::HashMap;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+use hashbrown::hash_map::Values;
+use hashbrown::HashMap;
 
 /// Lookup mechanism that uses inexact matching of input paths by finding the most specific
 /// match and returning that instead.  See [`PathMatcher::lookup`] for more information.

--- a/src/app/request.rs
+++ b/src/app/request.rs
@@ -1,3 +1,4 @@
+use alloc::{string::String, vec::Vec};
 use coap_lite::{CoapRequest, CoapResponse, RequestType, ResponseType};
 
 use crate::app::response::Response;

--- a/src/app/request_handler.rs
+++ b/src/app/request_handler.rs
@@ -1,7 +1,8 @@
 use crate::app::{CoapError, Request, Response};
+use alloc::boxed::Box;
 use async_trait::async_trait;
+use core::future::Future;
 use dyn_clone::DynClone;
-use std::future::Future;
 
 #[async_trait]
 pub trait RequestHandler<Endpoint>: DynClone + 'static {

--- a/src/app/resource_builder.rs
+++ b/src/app/resource_builder.rs
@@ -1,10 +1,15 @@
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::sync::Arc;
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::sync::Arc;
+use core::fmt::Debug;
+use core::hash::Hash;
+use hashbrown::HashMap;
 
 use coap_lite::link_format::LINK_ATTR_OBSERVABLE;
 use coap_lite::RequestType;
+#[cfg(feature = "embassy")]
+use embassy_util::{blocking_mutex::raw::CriticalSectionRawMutex, mutex::Mutex};
+#[cfg(feature = "tokio")]
 use tokio::sync::Mutex;
 
 use crate::app::app_builder::ConfigBuilder;
@@ -172,7 +177,11 @@ impl<Endpoint: Debug + Clone + Eq + Hash + Ord + Send + 'static> ResourceBuilder
 #[derive(Clone)]
 pub(crate) struct BuildParameters<Endpoint: Debug + Clone + Eq + Hash> {
     pub mtu: Option<u32>,
+    #[cfg(feature = "tokio")]
     pub retransmission_manager: Arc<Mutex<RetransmissionManager<Endpoint>>>,
+    #[cfg(feature = "embassy")]
+    pub retransmission_manager:
+        Arc<Mutex<CriticalSectionRawMutex, RetransmissionManager<Endpoint>>>,
 }
 
 #[derive(Clone)]

--- a/src/app/resource_handler.rs
+++ b/src/app/resource_handler.rs
@@ -1,15 +1,22 @@
-use std::collections::HashMap;
-use std::fmt::Debug;
-use std::hash::Hash;
-use std::sync::Arc;
+use alloc::boxed::Box;
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+use core::fmt::Debug;
+use core::hash::Hash;
+use hashbrown::HashMap;
+use rand::Rng;
 
-use coap_lite::{BlockHandler, CoapOption, CoapRequest, MessageType, Packet};
+use coap_lite::{BlockHandler, CoapRequest, Packet};
+#[cfg(feature = "embassy")]
+use embassy_util::{
+    blocking_mutex::raw::CriticalSectionRawMutex, channel::mpmc::DynamicSender as UnboundedSender,
+    mutex::Mutex,
+};
 use log::debug;
-use tokio::sync::mpsc::UnboundedSender;
-use tokio::sync::Mutex;
+#[cfg(feature = "tokio")]
+use tokio::sync::{mpsc::UnboundedSender, Mutex};
 
 use crate::app::observe_handler::{ObserveHandler, RegistrationEvent};
-use crate::app::observers::NotificationState;
 use crate::app::request_handler::RequestHandler;
 use crate::app::request_type_key::RequestTypeKey;
 use crate::app::retransmission_manager::RetransmissionManager;
@@ -17,9 +24,19 @@ use crate::app::{CoapError, Request};
 
 pub struct ResourceHandler<Endpoint: Debug + Clone + Ord + Eq + Hash> {
     pub handlers: HashMap<RequestTypeKey, Box<dyn RequestHandler<Endpoint> + Send + Sync>>,
+    #[cfg(feature = "tokio")]
     pub observe_handler: Option<Arc<Mutex<ObserveHandler<Endpoint>>>>,
+    #[cfg(feature = "tokio")]
     pub block_handler: Option<Arc<Mutex<BlockHandler<Endpoint>>>>,
+    #[cfg(feature = "tokio")]
     pub retransmission_manager: Arc<Mutex<RetransmissionManager<Endpoint>>>,
+    #[cfg(feature = "embassy")]
+    pub observe_handler: Option<Arc<Mutex<CriticalSectionRawMutex, ObserveHandler<Endpoint>>>>,
+    #[cfg(feature = "embassy")]
+    pub block_handler: Option<Arc<Mutex<CriticalSectionRawMutex, BlockHandler<Endpoint>>>>,
+    #[cfg(feature = "embassy")]
+    pub retransmission_manager:
+        Arc<Mutex<CriticalSectionRawMutex, RetransmissionManager<Endpoint>>>,
 }
 
 impl<Endpoint: Debug + Clone + Ord + Eq + Hash> Clone for ResourceHandler<Endpoint> {
@@ -39,10 +56,11 @@ impl<Endpoint: Debug + Clone + Ord + Eq + Hash> Clone for ResourceHandler<Endpoi
 }
 
 impl<Endpoint: Debug + Clone + Eq + Hash + Ord + Send + 'static> ResourceHandler<Endpoint> {
-    pub async fn handle(
+    pub async fn handle<R: Rng>(
         &self,
-        tx: &UnboundedSender<Packet>,
+        out: &mut Vec<Packet>,
         wrapped_request: Request<Endpoint>,
+        rng: &mut R,
     ) -> Result<(), CoapError> {
         let method = *wrapped_request.original.get_method();
         let method_handler = self
@@ -53,7 +71,7 @@ impl<Endpoint: Debug + Clone + Eq + Hash + Ord + Send + 'static> ResourceHandler
         // Loop here so we can "park" to wait for notify_change calls from an Observers
         // instances.  For non-observe cases, this loop breaks after its first iteration.
         match method_handler {
-            Some(handler) => self.do_handle(handler, tx, wrapped_request).await,
+            Some(handler) => self.do_handle(handler, out, wrapped_request, rng).await,
             None => Err(CoapError::method_not_allowed()),
         }
     }
@@ -62,11 +80,12 @@ impl<Endpoint: Debug + Clone + Eq + Hash + Ord + Send + 'static> ResourceHandler
     // these parts are especially expensive as it contains the request/response payloads and this
     // can be avoided by rethinking the Request/Response type system a bit and divorcing ourselves
     // from CoapRequest/CoapResponse.
-    async fn do_handle(
+    async fn do_handle<R: Rng>(
         &self,
         handler: &Box<dyn RequestHandler<Endpoint> + Send + Sync>,
-        tx: &UnboundedSender<Packet>,
+        out: &mut Vec<Packet>,
         wrapped_request: Request<Endpoint>,
+        rng: &mut R,
     ) -> Result<(), CoapError> {
         let mut initial_pair = wrapped_request.original.clone();
         if !self.maybe_handle_block_request(&mut initial_pair).await? {
@@ -80,15 +99,14 @@ impl<Endpoint: Debug + Clone + Eq + Hash + Ord + Send + 'static> ResourceHandler
             fut.await?
         }
         let registration = self
-            .maybe_handle_observe_registration(&mut initial_pair)
+            .maybe_handle_observe_registration(&mut initial_pair, rng)
             .await?;
-        tx.send(initial_pair.response.as_ref().unwrap().message.clone())
-            .unwrap();
+        out.push(initial_pair.response.as_ref().unwrap().message.clone());
 
         if let RegistrationEvent::Registered(mut receiver) = registration {
             debug!("Observe initiated by {:?}", initial_pair.source);
-            loop {
-                tokio::select! {
+            /*loop {
+                futures_util::select! {
                     _ = &mut receiver.termination_rx => {
                         debug!("Observe terminated by peer: {:?}", initial_pair.source);
                         break
@@ -143,7 +161,9 @@ impl<Endpoint: Debug + Clone + Eq + Hash + Ord + Send + 'static> ResourceHandler
                         }
                     }
                 }
-            }
+            }*/
+
+            todo!()
         }
 
         Ok(())
@@ -185,15 +205,16 @@ impl<Endpoint: Debug + Clone + Eq + Hash + Ord + Send + 'static> ResourceHandler
         }
     }
 
-    async fn maybe_handle_observe_registration(
+    async fn maybe_handle_observe_registration<R: Rng>(
         &self,
         request: &mut CoapRequest<Endpoint>,
+        rng: &mut R,
     ) -> Result<RegistrationEvent, CoapError> {
         if let Some(observe_handler) = &self.observe_handler {
             observe_handler
                 .lock()
                 .await
-                .maybe_process_registration(request)
+                .maybe_process_registration(request, rng)
                 .await
         } else {
             Ok(RegistrationEvent::NoChange)

--- a/src/app/retransmission_manager.rs
+++ b/src/app/retransmission_manager.rs
@@ -1,3 +1,5 @@
+#![allow(dead_code)]
+
 use alloc::string::String;
 use anyhow::anyhow;
 use core::fmt::{self, Debug};
@@ -8,10 +10,7 @@ use hashbrown::HashMap;
 
 use coap_lite::{MessageType, Packet};
 #[cfg(feature = "embassy")]
-use embassy_executor::time::Instant;
-#[cfg(feature = "embassy")]
 use embassy_util::channel::mpmc::DynamicSender as UnboundedSender;
-use log::debug;
 use rand::Rng;
 #[cfg(feature = "tokio")]
 use tokio::{
@@ -176,7 +175,8 @@ impl<Endpoint: Debug> SendReliably<'_, Endpoint> {
         self.packet.header.message_id
     }
 
-    /*pub async fn into_future<R: Rng>(self, mut rng: R) -> Result<(), SendFailed> {
+    #[cfg(feature = "observable")]
+    pub async fn into_future<R: Rng>(self, mut rng: R) -> Result<(), SendFailed> {
         let mut next_timeout = rng.gen_range(self.parameters.ack_timeout_range());
         for attempt in 0..=self.parameters.max_retransmit {
             if attempt > 0 {
@@ -191,7 +191,7 @@ impl<Endpoint: Debug> SendReliably<'_, Endpoint> {
                     next_timeout.as_micros().try_into().unwrap(),
                 );
             next_timeout *= 2;
-            /*loop {
+            loop {
                 let mut reply_rx = self.reply_rx.clone();
                 let timeout = time::timeout_at(deadline, reply_rx.changed());
                 match timeout.await {
@@ -210,11 +210,10 @@ impl<Endpoint: Debug> SendReliably<'_, Endpoint> {
                     },
                     Err(_) => break,
                 };
-            }*/
-            todo!()
+            }
         }
         Err(SendFailed::NoReply(self.parameters.max_retransmit + 1))
-    }*/
+    }
 }
 
 #[derive(Debug)]

--- a/src/app/u24.rs
+++ b/src/app/u24.rs
@@ -1,7 +1,7 @@
 //! Bit of a toy implementation of a "proper" u24 representation.  Isn't learning Rust fun? :)
 
-use std::fmt::{Debug, Display, Formatter};
-use std::ops::{Add, AddAssign};
+use core::fmt::{Debug, Display, Formatter};
+use core::ops::{Add, AddAssign};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
 #[allow(non_camel_case_types)]
@@ -38,13 +38,13 @@ impl u24 {
 }
 
 impl Display for u24 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         Display::fmt(&self.0, f)
     }
 }
 
 impl Debug for u24 {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         Debug::fmt(&self.0, f)
     }
 }
@@ -127,7 +127,7 @@ impl From<u24> for u64 {
 pub struct TryFromCustomIntError;
 
 impl Display for TryFromCustomIntError {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         f.write_str("out of range integral type conversion attempted")
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,14 +31,20 @@
 //!
 //! See other [examples](https://github.com/jasta/coap-server-rs/tree/main/examples) for more information.
 
+#![no_std]
+#![feature(type_alias_impl_trait)]
+
+#[macro_use]
+extern crate alloc;
+#[macro_use]
 extern crate core;
 
 pub use server::CoapServer;
 pub use server::FatalServerError;
-pub use udp::UdpTransport;
+// pub use udp::UdpTransport;
 
 pub mod app;
 pub mod packet_handler;
 pub mod server;
 pub mod transport;
-pub mod udp;
+// pub mod udp;

--- a/src/packet_handler.rs
+++ b/src/packet_handler.rs
@@ -1,7 +1,9 @@
-use std::pin::Pin;
+use core::pin::Pin;
 
+use alloc::boxed::Box;
 use coap_lite::Packet;
 use futures::Stream;
+use rand::Rng;
 
 /// "Low-level" raw packet handler intended to support the full range of CoAP features.  This
 /// is little more than a callback informing the user that a packet has arrived, allowing for
@@ -17,18 +19,20 @@ pub trait PacketHandler<Endpoint>: Clone {
     ) -> Pin<Box<dyn Stream<Item = Packet> + Send + 'a>>;
 }
 
-pub trait IntoHandler<Handler, Endpoint>
+pub trait IntoHandler<Handler, Endpoint, R>
 where
     Handler: PacketHandler<Endpoint> + Send + 'static,
+    R: Rng + Send + Clone,
 {
-    fn into_handler(self, mtu: Option<u32>) -> Handler;
+    fn into_handler(self, mtu: Option<u32>, rng: R) -> Handler;
 }
 
-impl<Handler, Endpoint> IntoHandler<Handler, Endpoint> for Handler
+impl<Handler, Endpoint, R> IntoHandler<Handler, Endpoint, R> for Handler
 where
     Handler: PacketHandler<Endpoint> + Send + 'static,
+    R: Rng + Send + Clone,
 {
-    fn into_handler(self, _mtu: Option<u32>) -> Handler {
+    fn into_handler(self, _mtu: Option<u32>, rng: R) -> Handler {
         self
     }
 }

--- a/src/packet_handler.rs
+++ b/src/packet_handler.rs
@@ -32,7 +32,7 @@ where
     Handler: PacketHandler<Endpoint> + Send + 'static,
     R: Rng + Send + Clone,
 {
-    fn into_handler(self, _mtu: Option<u32>, rng: R) -> Handler {
+    fn into_handler(self, _mtu: Option<u32>, _rng: R) -> Handler {
         self
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1,24 +1,36 @@
-use std::fmt::Debug;
-use std::pin::Pin;
+use core::fmt::{self, Debug};
+use core::pin::Pin;
 
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
 use coap_lite::Packet;
+use embassy_executor::executor::raw::TaskPool;
+use embassy_executor::executor::{SendSpawner, Spawner};
+use embassy_util::Either;
+#[cfg(feature = "embassy")]
+use embassy_util::{
+    blocking_mutex::raw::CriticalSectionRawMutex,
+    channel::mpmc::{DynamicReceiver, DynamicSender},
+};
 use futures::stream::Fuse;
-use futures::{SinkExt, StreamExt};
+use futures::{Future, SinkExt, StreamExt};
 use log::{error, trace, warn};
+use rand::{Rng, RngCore};
+#[cfg(feature = "tokio")]
 use tokio::sync::mpsc::{Receiver, Sender};
 
 use crate::packet_handler::{IntoHandler, PacketHandler};
 use crate::transport::{FramedBinding, FramedItem, FramedReadError, Transport, TransportError};
 
 /// Primary server API to configure, bind, and ultimately run the CoAP server.
-pub struct CoapServer<Handler, Endpoint> {
+pub struct CoapServer<'a, Handler, Endpoint> {
     binding: Fuse<Pin<Box<dyn FramedBinding<Endpoint>>>>,
-    packet_relay_rx: Receiver<FramedItem<Endpoint>>,
-    packet_relay_tx: Sender<FramedItem<Endpoint>>,
+    packet_relay_rx: DynamicReceiver<'a, FramedItem<Endpoint>>,
+    packet_relay_tx: DynamicSender<'a, FramedItem<Endpoint>>,
     handler: Option<Handler>,
 }
 
-impl<Handler, Endpoint: Debug + Send + Clone + 'static> CoapServer<Handler, Endpoint>
+impl<'a, Handler, Endpoint: Debug + Send + Clone + 'static> CoapServer<'a, Handler, Endpoint>
 where
     Handler: PacketHandler<Endpoint> + Send + 'static,
 {
@@ -26,9 +38,17 @@ where
     /// customers will wish to use [`crate::udp::UdpTransport`].
     pub async fn bind<T: Transport<Endpoint = Endpoint>>(
         transport: T,
-    ) -> Result<Self, TransportError> {
+    ) -> Result<CoapServer<'a, Handler, Endpoint>, TransportError> {
         let binding = transport.bind().await?;
-        let (packet_tx, packet_rx) = tokio::sync::mpsc::channel(32);
+        let channel = Box::new(embassy_util::channel::mpmc::Channel::<
+            CriticalSectionRawMutex,
+            _,
+            32,
+        >::new());
+        // FIXME: avoid memory leak
+        let channel = Box::leak(channel);
+        let packet_tx = channel.sender().into();
+        let packet_rx = channel.receiver().into();
         Ok(Self {
             binding: binding.fuse(),
             packet_relay_rx: packet_rx,
@@ -41,33 +61,34 @@ where
     /// encounters unrecoverable issues, typically due to programmer error in this crate itself
     /// or transport errors not related to a specific peer.  The intention is that this crate
     /// should be highly reliable and run indefinitely for properly configured use cases.
-    pub async fn serve(
+    pub async fn serve<R: Rng + Send + Clone>(
         mut self,
-        handler: impl IntoHandler<Handler, Endpoint>,
+        handler: impl IntoHandler<Handler, Endpoint, R>,
+        rng: R,
     ) -> Result<(), FatalServerError> {
         let mtu = self.binding.get_ref().mtu();
-        self.handler = Some(handler.into_handler(mtu));
+        self.handler = Some(handler.into_handler(mtu, rng));
 
+        let spawner = embassy_executor::executor::Spawner::for_current_executor().await;
         loop {
-            tokio::select! {
-                event = self.binding.select_next_some() => {
-                    self.handle_rx_event(event)?;
-                }
-                Some(item) = self.packet_relay_rx.recv() => {
-                    self.handle_packet_relay(item).await;
-                }
+            match embassy_util::select(self.binding.select_next_some(), self.packet_relay_rx.recv())
+                .await
+            {
+                Either::First(event) => self.handle_rx_event(event, spawner).await?,
+                Either::Second(item) => self.handle_packet_relay(item).await,
             }
         }
     }
 
-    fn handle_rx_event(
+    async fn handle_rx_event(
         &self,
         result: Result<FramedItem<Endpoint>, FramedReadError<Endpoint>>,
+        spawner: Spawner,
     ) -> Result<(), FatalServerError> {
         match result {
             Ok((packet, peer)) => {
                 trace!("Incoming packet from {peer:?}: {packet:?}");
-                self.do_handle_request(packet, peer)?
+                self.do_handle_request(packet, peer, spawner).await?
             }
             Err((transport_err, peer)) => {
                 warn!("Error from {peer:?}: {transport_err}");
@@ -80,7 +101,12 @@ where
         Ok(())
     }
 
-    fn do_handle_request(&self, packet: Packet, peer: Endpoint) -> Result<(), FatalServerError> {
+    async fn do_handle_request(
+        &self,
+        packet: Packet,
+        peer: Endpoint,
+        _spawner: Spawner,
+    ) -> Result<(), FatalServerError> {
         let handler = self
             .handler
             .as_ref()
@@ -91,23 +117,22 @@ where
             packet,
             peer,
         );
-        tokio::spawn(reply_stream);
+        // FIXME: should spawn the task onto executor but embassy can spawn only
+        // static futures.
+        reply_stream.await;
         Ok(())
     }
 
     async fn gen_and_send_responses(
         handler: Handler,
-        packet_tx: Sender<FramedItem<Endpoint>>,
+        packet_tx: DynamicSender<'_, FramedItem<Endpoint>>,
         packet: Packet,
         peer: Endpoint,
     ) {
         let mut stream = handler.handle(packet, peer.clone());
         while let Some(response) = stream.next().await {
             let cloned_peer = peer.clone();
-            packet_tx
-                .send((response, cloned_peer))
-                .await
-                .expect("packet_rx closed?");
+            packet_tx.send((response, cloned_peer)).await;
         }
     }
 
@@ -122,14 +147,27 @@ where
 
 /// Fatal error preventing the server from starting or continuing.  Typically the result of
 /// programmer error or misconfiguration.
-#[derive(thiserror::Error, Debug)]
+#[derive(Debug)]
 pub enum FatalServerError {
     /// Programmer error within this crate, file a bug!
-    #[error("internal error: {0}")]
     InternalError(String),
 
     /// Transport error that is not related to any individual peer but would prevent any future
     /// packet exchanges on the transport.  Must abort the server.
-    #[error("fatal transport error: {0}")]
-    Transport(#[from] TransportError),
+    Transport(TransportError),
+}
+
+impl fmt::Display for FatalServerError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::InternalError(err) => write!(f, "internal error: {}", err),
+            Self::Transport(err) => write!(f, "fatal transport error: {}", err),
+        }
+    }
+}
+
+impl From<TransportError> for FatalServerError {
+    fn from(err: TransportError) -> Self {
+        Self::Transport(err)
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,8 +4,7 @@ use core::pin::Pin;
 use alloc::boxed::Box;
 use alloc::string::{String, ToString};
 use coap_lite::Packet;
-use embassy_executor::executor::raw::TaskPool;
-use embassy_executor::executor::{SendSpawner, Spawner};
+use embassy_executor::executor::Spawner;
 use embassy_util::Either;
 #[cfg(feature = "embassy")]
 use embassy_util::{
@@ -13,9 +12,9 @@ use embassy_util::{
     channel::mpmc::{DynamicReceiver, DynamicSender},
 };
 use futures::stream::Fuse;
-use futures::{Future, SinkExt, StreamExt};
+use futures::{SinkExt, StreamExt};
 use log::{error, trace, warn};
-use rand::{Rng, RngCore};
+use rand::Rng;
 #[cfg(feature = "tokio")]
 use tokio::sync::mpsc::{Receiver, Sender};
 


### PR DESCRIPTION
This PR contains a WIP support for embassy.

Currently, the implementation is working and I can run CoAP server on nRF52840 target, but it breaks tokio. Changes done:
- where possible replaced std imports with core/alloc imports
- added tokio and embassy features
- made observable resource support an optional feature - currently, observable resources are not supported on embassy and must be disabled
- RNG is passed as argument instead of `rand::thread_rng()`
- removal of future spawning - ~~embassy requires that all spawned futures must be 'static which caused major problems~~
  EDIT: TaskPool used for spawning futures requires `self: &'static Self`, futures must be 'static, not `&'static`. So taskpool would have to be declared as static and passed to CoAP server, to declare static variable we must known concrete type of the future to be spawned with TaskPool, `static POOL: TaskPool<impl Future>` won't work. AFAIK it's not possible to use `async move {}` - futures need to be created by implementing `Future` trait.

Closes #8 and #3 